### PR TITLE
Updated TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 language: go
 
 go:
-  - 1.6.x
   - 1.7.x
   - 1.8.x
+  - 1.9.x
   - tip
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - go: tip
+    - os: osx
 
 before_install:
   - make deps


### PR DESCRIPTION
Due to various degradation of TravisCI OSX infrastructure, the build fails on OSX is allowed for now.